### PR TITLE
Fix typo in attribute name

### DIFF
--- a/src/main/java/org/primefaces/component/captcha/CaptchaRenderer.java
+++ b/src/main/java/org/primefaces/component/captcha/CaptchaRenderer.java
@@ -75,7 +75,7 @@ public class CaptchaRenderer extends CoreRenderer {
         
         wb.attr("sitekey", publicKey)
             .attr("theme", captcha.getTheme(), "light")
-            .attr("languagage", captcha.getLanguage(), "en")
+            .attr("language", captcha.getLanguage(), "en")
             .attr("tabindex", captcha.getTabindex(), 0);
         
         wb.finish();


### PR DESCRIPTION
The language attribute for the reCaptcha2 was misspelled. This leads to the captcha always being generated in English.